### PR TITLE
SPP-258 | Fix scroll spy desyncing issue (<details> elements expandin…

### DIFF
--- a/src/components/menu/menu-item.js
+++ b/src/components/menu/menu-item.js
@@ -69,6 +69,11 @@ export default class MenuItem extends Component {
     }
 
     componentWillReceiveProps(props) {
+        //If there's a new click event, trigger the recalc of scroll spy offset
+        if (this.props.containerHeight !== props.containerHeight) {
+            this.resetScrollSpyHeights();
+        }
+
         //Propagate active article and roles down the menu chain
         const activeArticle = this.state.onPage ? this.state.activeArticle : props.activeArticle;
         this.setState({
@@ -100,6 +105,7 @@ export default class MenuItem extends Component {
                     const articleLoad = load;
                     timeout = setTimeout(function () {
                         if (this.state.activeArticle === activeArticle) {
+                            this.resetScrollSpyHeights();
                             EVENTS_DISPATCH.ARTICLE(activeArticle, clickedArticle ? ACTIONS.articleClick : articleLoad ? ACTIONS.articleLoad : ACTIONS.articleScroll);
                         }
                     }.bind(this), 2000);
@@ -107,11 +113,11 @@ export default class MenuItem extends Component {
                     sessionStorage.removeItem('article.clicked');
                     this.setState({activeArticle: activeArticle});
                 }
-
             }
         });
         load = false;
     }
+
 
     render() {
         const item = this.props.item;

--- a/src/components/menu/menu.js
+++ b/src/components/menu/menu.js
@@ -29,11 +29,40 @@ class Menu extends Component {
             children: this.props.menu.children,
             roles: this.roleFilter(),
             expanded: false,
+            containerHeight: 0
         };
+
+
         this.filterByRole(this.state.roles.selected);
+        this.mountContainerListener = this.mountContainerListener.bind(this)
+        this.unMountContainerListener = this.unMountContainerListener.bind(this)
+    }
+
+    /**
+     * Manually handle click events in Presidium Container
+     * that might desync the offset of scroll spy element
+     * (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)
+     */
+    mountContainerListener() {
+        const _container = document.getElementById('presidium-content');
+
+        _container
+            .addEventListener("click", (e) => {
+                //If container did resize
+                if (this.state.containerHeight !== _container.clientHeight) {
+                    this.setState({containerHeight: _container.clientHeight})
+                }
+            })
+    }
+
+    unMountContainerListener() {
+        document.getElementById("presidium-content")
+            .removeEventListener("click");
     }
 
     componentDidMount() {
+        this.mountContainerListener();
+
         window.events.subscribe({
             next: (event) => {
                 if (event.topic === TOPICS.ROLE_UPDATED) {
@@ -42,6 +71,11 @@ class Menu extends Component {
             }
         });
     }
+
+    componentWillUnmount() {
+        this.unMountContainerListener();
+    }
+
 
     roleFilter() {
         let selected;
@@ -92,6 +126,7 @@ class Menu extends Component {
                             {
                                 this.state.children.map(item => {
                                     return <MenuItem
+                                        containerHeight={this.state.containerHeight}
                                         key={item.id}
                                         baseUrl={this.props.menu.baseUrl}
                                         item={item}
@@ -118,7 +153,10 @@ class Menu extends Component {
             <div className="filter form-group">
                 {this.state.roles.label &&
                 <label className="control-label" htmlFor="roles-select">{this.state.roles.label}:</label>}
-                <select ref="roleselector" id="roles-select" className="form-control" value={this.state.roles.selected}
+                <select ref="roleselector"
+                        id="roles-select"
+                        className="form-control"
+                        value={this.state.roles.selected}
                         onChange={(e) => this.onFilterRole(e)}>
                     {this.state.roles.options.map(role => {
                         return <option key={role} value={role}>{role}</option>


### PR DESCRIPTION
…g etc)

The issue here is that if Presidium users use any functions or elements that dynamically change the height of the content viewport, the scroll spy is 'desynced'. Here's an example: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary

Two changes are made in this branch: 

- There's a event listener in the `<Menu>` component that will listen for viewport height changes. At the moment, it's being done by listening for click events that will only update state if the viewport's height changes. 

- Each time a new menu item is highlighted, the scroll spy will automatically recalculate - a relatively inexpensive operation. 