### PR TITLE
Keep section expanded in menu if marked as alwaysExpanded

### DIFF
--- a/src/components/menu/menu-item.js
+++ b/src/components/menu/menu-item.js
@@ -21,14 +21,14 @@ export default class MenuItem extends Component {
         const onPage = itemURL === window.location.pathname;
         const inSection = this.inSection();
         const hasChildren = props.item.children.length > 0;
-
         this.state = {
             onPage: onPage,
             inSection: onPage || inSection,
+            alwaysExpanded: this.props.item.alwaysExpanded,
             isCollapsed: this.props.item.collapsed,
             hasChildren: hasChildren,
             activeArticle: this.props.activeArticle,
-            isExpanded: inSection && hasChildren,
+            isExpanded: (inSection || this.props.item.alwaysExpanded) && hasChildren,
             selectedRole: this.props.roles.selected,
             newTab: this.props.item.newTab,
         };
@@ -259,7 +259,7 @@ export default class MenuItem extends Component {
 
     toggleExpand(e) {
         e.stopPropagation();
-        if (this.state.hasChildren) {
+        if (this.state.hasChildren && !this.state.alwaysExpanded) {
             this.setState({isExpanded: !this.state.isExpanded})
         }
     }


### PR DESCRIPTION
This review if depended on https://github.com/SPANDigital/presidium-core/pull/95. Please merge that first.

SPP-881 | AH-76 | Keep section expanded in menu if marked as alwaysExpanded

The section in the menu will always be expanded i.e. setting it as expanded on initial render and preventing toggle on the expander