### PR TITLE
AH-101 | Remove urlArgs keys set in localstorage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,16 @@ import React from 'react';
 import {loadMenu} from './components/menu/menu';
 import {init as initModal} from './components/image/modal';
 import {loadTooltips} from './components/tooltips/tooltips';
-import {handleQueryString, checkSessionStorageConfig} from './util/config';
+// import {handleQueryString, checkSessionStorageConfig} from './util/config';
 import {Subject} from 'rxjs/Subject'
 
 initModal();
-handleQueryString(); //Check query string arguments and persist to sessionStorage
-checkSessionStorageConfig(); //Check sessionStorage for known configurations and apply them
+// TODO: Find a solution that is easier on the local storage if needed for edit mode.
+//       Safari returns and error with 303 when local storage exceeds the limit for the domain
+//       https://macreports.com/safari-kcferrordomaincfnetwork-error-blank-page-fix/
+//       https://www.quora.com/Why-does-Safari-give-me-a-kCFErrorDomainCFNetwork-error-303-when-browsing-some-sites
+// handleQueryString(); //Check query string arguments and persist to sessionStorage
+// checkSessionStorageConfig(); //Check sessionStorage for known configurations and apply them
 
 var presidium = {
     menu: {


### PR DESCRIPTION
AH-101 | Remove urlArgs keys set in localstorage to prevent reaching storage limit on safari for bigger sites