### PR TITLE
Expand Navbar Menus When Scrolling

### DIFF
--- a/src/util/scroll-spy.js
+++ b/src/util/scroll-spy.js
@@ -263,6 +263,7 @@
 		li.classList.remove('closed');
 		li.classList.add('in');
 
+		// Loop through all children and expand them since we are browsing through this section
 		li.querySelector('a > .menu-expander > span').classList.remove('glyphicon-chevron-right');
 		li.querySelector('a > .menu-expander > span').classList.add('glyphicon-chevron-down');
 


### PR DESCRIPTION
Automatically expand navbar menus when scrolling through articles. Close them when navigating away.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-2759

### Screenshots
https://user-images.githubusercontent.com/35559164/194093208-e6db1165-0504-4e4b-af20-24bc1c001630.mov

