### PR TITLE
PRS-3177: Release build to GH instead of S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,6 @@ jobs:
     script:
     - npm run build
     - "./build/github_release.sh"
-    deploy:
-    - provider: s3
-      access_key_id: AKIA2WMSJGXU3J5T27XB
-      secret_access_key:
-        secure: MWxsVyCwNb9/A+mMI3/5Fcgs/HnCisQ1tPXqoXYNiJnlOgQUzd3vbcOFTLm2zu4jKCgspctIv9/zuGPfU/Cgnj3x8mYk3CyKfsaWZ6Dq4DGXHLmxPjpyhheZoN609utnW56otv8pMNpFMsljlZ2nWjET4wNnD0TpxILY0cqvixVCv0Hv0MmjwWx+DMz4NHlKBApp3z7AE7fo052sdN+Z0PNOfJCQfpNlhg1M6b+9g+bDN0jYuLjBNSUw0p3UmBtitYJ8c/RiOrAgsKL6PG6A+8WF+XV/enapDaWL+wcFIrSfIlHMlZ+a5u5Em+DN8FbJfXDqiLBjhBh6yySO7WxzY1oQpyDVkwLFheQ5QjDjMmkwxFTK6cq12sAnwrp7vngadWKgt62Tstm1w2vczEDl7TZUqhrLw8AzVqEw5j5l+ZM+liOeXomYrzYVz/2oh3BunKTfA9mJ8meP1Zvb42PDxQAABHVOI5qArlIAdYLxhdBDONHTtXTU9FMGkn1qplQuEJavJdxrQf1tmiFhCZJiRDlLxMNAuOiuqbGBpm2XqG77L7LRxxIBns5dAcOLSprUVTVE/0r5v6nNSwTPx4TJ9GMOR4EaBVpLX0zR7iPg9BDSLZN7ho7cpRTeCix+NXBugm8UPZAP+N4sS7h6tFq6zZY/q4fkCtoJJGfahWPKNP8=
-      bucket: span-presidium
-      local-dir: dist
-      upload-dir: presidium-js/$TRAVIS_TAG
-      skip_cleanup: true
-      on:
-        tags: true
 env:
   global:
   - REPO=spandigital/presidium-js

--- a/build/github_release.sh
+++ b/build/github_release.sh
@@ -10,7 +10,7 @@ source "${DIR}/include.sh"
 # TRAVIS_TAG=your_release_version GITHUB_KEY=your_github_key ./build/github_release.sh
 # Before running this script, you will need to run "npm run build" 
 
-if [[ -n "${TRAVIS_TAG}" ]]
+if [[ -n "${TRAVIS_TAG}" && "${TRAVIS_BRANCH}" = "master" ]]
 then
     zip_file=$TRAVIS_TAG.zip
 

--- a/build/github_release.sh
+++ b/build/github_release.sh
@@ -5,7 +5,29 @@ set -e
 DIR="$(dirname "$0")"
 source "${DIR}/include.sh"
 
-if [[ -n "${TRAVIS_TAG}" && ${TRAVIS_TAG} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+# This script will create a release on GitHub with build artifacts attached
+# To run this script manually, you can use the following command:
+# TRAVIS_TAG=your_release_version GITHUB_KEY=your_github_key ./build/github_release.sh
+# Before running this script, you will need to run "npm run build" 
+
+if [[ -n "${TRAVIS_TAG}" ]]
 then
-    curl -v -d "{\"tag_name\": \"$TRAVIS_TAG\"}" -H "Authorization: token ${GITHUB_KEY}" -X POST "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/releases"
+    zip_file=$TRAVIS_TAG.zip
+
+    # Zip the dist folder
+    zip -r -qq $zip_file dist
+
+    # Create a release on GitHub
+    release=$(curl -s -d "{\"tag_name\": \"$TRAVIS_TAG\"}" -H "Authorization: token ${GITHUB_KEY}" -X POST "https://api.github.com/repos/SPANDigital/presidium-js/releases")
+
+    # Get the upload url from the release
+    upload_url=$(echo $release | jq -r '.upload_url')
+    
+    # Remove the {?name,label} from the upload_url
+    upload_url="${upload_url//\{?name,label\}/}"
+
+    # Upload the zip file to the release
+    curl -s -H "Authorization: token ${GITHUB_KEY}" -H "Content-Type: application/zip" --data-binary @$zip_file "$upload_url?name=$zip_file"
+
+    rm $zip_file
 fi


### PR DESCRIPTION
<!-- PROJ-123: Short description of change -->

### Description
This PR updates the TravisCI and the release script to publish the build artifacts to Github instead of S3. It will automatically create a new release on Github when you merge to master and it will upload a zip of the dist folder to the release. E.g https://github.com/SPANDigital/presidium-js/releases/tag/v0.0.1.test.5

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3177
