### PR TITLE
Filter out the nav items to prevent them from being seen as content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 2023-01-24
+### Bugfixes
+- Fixed an issue where the nav bar selection would jump to the bottom when scrolled to the top of the page. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3302

--- a/src/util/scroll-spy.js
+++ b/src/util/scroll-spy.js
@@ -334,8 +334,9 @@
 
 				// Get the content for the nav item
                 const target = item.getAttribute(options.attribute)
-				var content = document.getElementById(decodeURIComponent(target.substr(1)));
-				if (!content) return;
+				const id = decodeURIComponent(target.substr(1));
+				var content = document.getElementById(id);
+				if (!content || content.tagName !== 'DIV') return;
 
 				// Push to the contents array
 				contents.push({
@@ -358,12 +359,7 @@
 			// Get the active content
 			var active = getActive(contents, settings);
 
-			// if there's no active content, deactivate and bail
 			if (!active) {
-				if (current) {
-					deactivate(current, settings);
-					current = null;
-				}
 				return;
 			}
 


### PR DESCRIPTION
Filter out the nav items to prevent them from being seen as content. This is to fix a bug where the nav bar selection would jump to the bottom of the page when scrolled to the top. Thanks @DonnieTD for the assistance.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-3302

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
