### PR TITLE
Add class to have the ability to disable clicks on images

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build": "webpack --config webpack/webpack.config.js --env env=prod",
     "build:dev": "webpack --config webpack/webpack.config.js --env env=dev",
     "bundle-stats": "webpack -p --config webpack/webpack.config.js --env env=prod --json > dist/stats.json",
+    "watch": "webpack --watch --config webpack/webpack.config.js --env env=dev",
     "cm": "cz"
   },
   "devDependencies": {

--- a/src/components/image/modal.js
+++ b/src/components/image/modal.js
@@ -12,7 +12,7 @@ export function init() {
         }
     });
 
-    document.querySelectorAll('#presidium-content img').forEach(img => {
+    document.querySelectorAll('#presidium-content img:not(.no-click)').forEach(img => {
         img.className += ' ' + 'scalable';
         img.onclick = function() {
             modal.style.display = 'block';


### PR DESCRIPTION
We add a default click handler to all images in presidium content containers.  In some sites you would not want images to open up but rather redirect to another page.  This fix allows you to add a class to images to prevent the click handler from being added. 

Also added a webpack watch script.

### Issue
https://spandigital.atlassian.net/browse/PRSDM-4217

### Screenshots
This is used by [another PR](https://github.com/SPANDigital/span-chronicle-docs/pull/50) if you want see the usage.

### Checklist before merging

* [ ] Is this code covered by tests?
* [ ] Is the documentation updated for this change?
