### PR TITLE
fix: PRSDM-8871 - Fix navigation active state scroll spy offset calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-## 2023-01-24
+## 2025-08-22
 ### Bugfixes
-- Fixed an issue where the nav bar selection would jump to the bottom when scrolled to the top of the page. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3302
+- Fixed navigation active state issue where clicking menu items would highlight the wrong navigation item by replacing static scroll spy offset with dynamic calculation @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-8871
 
 ## 2024-01-10
 ### Updates
 - Added the Github team as the code owners @CharlRitterDev  https://spandigital.atlassian.net/browse/PRSDM-4891
+
+## 2023-01-24
+### Bugfixes
+- Fixed an issue where the nav bar selection would jump to the bottom when scrolled to the top of the page. @SamShiels https://spandigital.atlassian.net/browse/PRSDM-3302

--- a/src/index.js
+++ b/src/index.js
@@ -40,13 +40,13 @@ $(function () {
       const $navSectionLinks = $('#presidium-navigation .menu-row:not([data-roles="All Roles"])');
 
       $articles.each((i, article) => {
-        if (!( $(article).data('roles').includes(selectedRole) )){
+        if (!($(article).data('roles').includes(selectedRole))) {
           $(article).hide();
         }
       });
 
       $navSectionLinks.each((i, link) => {
-        if (! ($(link).data('roles').includes(selectedRole))){
+        if (!($(link).data('roles').includes(selectedRole))) {
           $(link).hide()
         }
       });
@@ -58,7 +58,7 @@ $(function () {
     const selectedRole = this.value;
     filterArticles(selectedRole);
   });
-  if ( cachedRole && $('#roles-select option:selected').text() !== cachedRole ){
+  if (cachedRole && $('#roles-select option:selected').text() !== cachedRole) {
     // When a page reloads occurs from navigating to a new section
     // reload the selected role and trigger the filter
     $('#roles-select').val(cachedRole);
@@ -67,15 +67,24 @@ $(function () {
   }
 });
 
-let offset = 0;
-const content = $('.article-title').get(0);
-if (content) {
-  offset = window.pageYOffset + content.getBoundingClientRect().top;
-}
-
 var spy = new scrollSpy('.navbar-items ul a', {
   attribute: 'data-target',
-  offset: offset,
+  offset: function () {
+    // Find the closest visible .article-title element to the top of the viewport
+    // and use its position as the dynamic offset for scroll spy detection
+    let closest = null;
+    let minDistance = Infinity;
+    
+    $('.article-title').each(function() {
+      const top = this.getBoundingClientRect().top;
+      if (top >= 0 && top < minDistance) {
+        minDistance = top;
+        closest = this;
+      }
+    });
+    
+    return closest ? minDistance : 50;
+  },
   navClass: 'active',
   nested: true,
   nestedClass: 'active', // applied to the parent items


### PR DESCRIPTION
  ## Description

  Fixed navigation active state issue where clicking menu items would highlight the wrong navigation item
  (typically the item above the clicked one).

  The scroll spy was using a static offset calculated at page load (`window.pageYOffset +
  content.getBoundingClientRect().top`), which didn't account for the current scroll position when determining
  which navigation item should be active.

  Replaced the static offset with a dynamic function that finds the closest visible `.article-title` element to the
   top of the viewport and uses its current position as the scroll spy offset threshold, recalculating on every
  scroll event to handle variable spacing between sections.

  ## Issue
  - [x] :clipboard: https://spandigital.atlassian.net/browse/PRSDM-8871

  ## Screenshots

- Before

https://github.com/user-attachments/assets/7344b8be-377a-41fa-b257-8cd97e6af4da

-After

https://github.com/user-attachments/assets/7981a9f5-6e60-45ef-b58a-e22bb859977e

## Testing Instructions
1. Have a local clone of presidium-layouts-base :
   1. Copy the local path to presidium-layouts-base/static
1. In presidium-js :
   1. add or update .env to set API_LOCATION to the path you copied
      - eg: API_LOCATION=/path/to/local/presidium-layouts-base/static
   1. npm run build
      - it should output presidium.js to presidium-layouts-base/static
1. In a test site presidium-test-validation/:
   1. in config.yml set it to point at your local version of presidium-layouts-base :
    ```
    module:
      imports:
        - path: github.com/spandigital/presidium-styling-base
        - path: path/to/local/presidium-layouts-base
        # - path: github.com/spandigital/presidium-layouts-base `
    ```
1. run hugo serve
1. check its all working

  ## PR Readiness Checks
  - [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix:
  PRSDM-123 issue with login` with a maximum of 100 characters
  - [x] You have performed a self-review of your changes via the GitHub UI
  - [x] Comments were added to new code that can not explain itself (see [reference 
  1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 
  2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
  - [x] New code adheres to the following quality standards:
    - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
    - Meaningful Names ([see 
  reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
    - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
    - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
  - [x] Tests were added to prove the correctness and ensure extendability of the functionality added (unless
  agreed upon by the reviewers that it's not necessary) and the changes were tested locally